### PR TITLE
Add localStorage form persistence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,45 @@
-# Lab: Form Storage
+# Form Storage Lab
 
-## Overview  
-Now that we’ve covered the basics of creating custom hooks, let’s use our skills to implement a popular feature when it comes to user convenience. You are working with a repair company and you want the user to be able to keep the inputted form data between refreshes. They don’t want to store it within a `db.json` file as that is less secure, however, we can use the user's local storage to store the data and create a custom hook in order to manipulate the local storage.
+## Overview
+This lab adds a reusable `useLocalStorage` custom hook to a React service form so the user's input survives a page refresh. The `name` and `serviceNumber` fields are stored in browser local storage instead of a database.
 
-## Task 1: Define the Problem  
-As a user, one should be able to:
-- Input data in the form.
-- Refresh the page.
-- See the form store the data.
+## Features
+- Persists the `name` field between refreshes.
+- Persists the `serviceNumber` field between refreshes.
+- Reuses the same `useLocalStorage` hook for both controlled inputs.
+- Displays a welcome message based on the saved name.
 
-## Task 2: Determine the Design  
-- Build a custom hook that will manipulate local storage.
+## Preview
+![Service form with persisted values](./public/form-storage-preview.svg)
 
-## Task 3: Develop the Code  
-- Create a custom hook, `useLocalStorage`, to manipulate the local storage of the user.
-- Connect the custom hook to the form to persist user data upon refresh.
+## Getting Started
+1. Install dependencies:
 
-## Task 4: Test and Refine  
-- Debug and test during development using the provided test suite and React DevTools in Chrome.
+```sh
+npm install
+```
 
-## Task 5: Document and Maintain  
-- Commit as you go, writing meaningful commit messages.
-- Push commit history to GitHub periodically and when the lab is complete.
+2. Start the development server:
 
----
-
-## Tools and Resources  
-- **React Custom Hooks:** [React Docs](https://react.dev/learn/reusing-logic-with-custom-hooks)  
-- **localStorage:** [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)  
-
----
-
-## Instructions  
-
-### Set Up  
-Before we begin coding, let's complete the initial setup for this lesson:
-
-#### Fork and Clone  
-1. Go to the provided GitHub repository link.
-2. Fork the repository to your GitHub account.
-3. Clone the forked repository to your local machine.
-4. Open the project in VSCode.
-5. Run `npm install` to install all necessary dependencies.
-
-### Task 1: Define the Problem  
-As a user, one should be able to:
-- Input data in the form.
-- Refresh the page.
-- See the form store the data.
-
-### Task 2: Determine the Design  
-- Build a custom hook that will manipulate local storage.
-
-### Task 3: Develop, Test, and Refine the Code  
-
-#### Open React application in the browser  
 ```sh
 npm run dev
 ```
 
-#### Run test suite  
+3. Run the test suite:
+
 ```sh
 npm run test
 ```
 
-#### Create feature branch  
-- **Create custom hook, `useLocalStorage`**
-  - `useLocalStorage` function will have **2 inputs**:
-    - `key`: The name of the input.
-    - `initialValue`: The initial value of the input.
-  - **Create a state** to represent input data:
-    - The initial value of the state is either the localStorage data or `initialValue`.
-    - **Hint:** Use `localStorage.getItem`.
-  - **Return state and setter function.**
-  - **Build `useEffect`** that will update the localStorage of the user:
-    - The dependency array includes both `key` and `state`.
-    - **Hint:** Use `localStorage.setItem` to set values in the local storage.
-- **Connect custom hook to form:**
-  - Connect to the `name` and `serviceNumber` fields of the form.
-  - Ensure the key of each is `"name"` and `"serviceNumber"` respectively.
-- **Push feature branch and open a PR on GitHub.**
-- **Merge to main.**
+## Implementation Notes
+- `useLocalStorage(key, initialValue)` reads the initial value from `localStorage` and falls back to the provided default.
+- A `useEffect` keeps local storage synchronized whenever the field state changes.
+- The form uses the hook with the required keys `name` and `serviceNumber`.
 
-### Task 4: Document and Maintain  
+## Project Structure
+- `src/hooks/useLocalStorage.js`: reusable persistence hook.
+- `src/components/Form.jsx`: service form wired to local storage-backed state.
 
-#### Best Practice Documentation Steps:
-- Add comments to the code to explain purpose and logic.
-- Clarify intent/functionality of code to other developers.
-- Add a screenshot of the completed work in Markdown in `README.md`.
-- Update `README.md` to reflect the functionality of the application following [this guide](https://makeareadme.com).
-- Delete any stale branches on GitHub.
-- Remove unnecessary/commented-out code.
-- If needed, update `.gitignore` to remove sensitive data.
-
----
-
-## Submission  
-Once all tests are passing and working code is pushed to the GitHub `main` branch, submit your GitHub repo through Canvas using CodeGrade.
-
-## Grading Criteria  
-The application passes all test suites.
-
-Ensure the application:
-- **Persists user data between refreshes.**
-- **Has a functional custom hook (`useLocalStorage`).**
+## Resources
+- [React Docs: Reusing Logic with Custom Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks)
+- [MDN: Window.localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)

--- a/public/form-storage-preview.svg
+++ b/public/form-storage-preview.svg
@@ -1,0 +1,14 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1280" height="720" fill="#f4f7fb"/>
+  <rect x="260" y="110" width="760" height="500" rx="28" fill="#ffffff" stroke="#d7e0ea" stroke-width="2"/>
+  <text x="330" y="190" fill="#16202a" font-family="Arial, sans-serif" font-size="42" font-weight="700">Service Form</text>
+  <text x="330" y="265" fill="#425466" font-family="Arial, sans-serif" font-size="24">Name:</text>
+  <rect x="330" y="280" width="620" height="64" rx="12" fill="#f9fbfd" stroke="#b9c7d6" stroke-width="2"/>
+  <text x="356" y="321" fill="#16202a" font-family="Arial, sans-serif" font-size="28">Alex Carter</text>
+  <text x="330" y="392" fill="#425466" font-family="Arial, sans-serif" font-size="24">Service Number:</text>
+  <rect x="330" y="407" width="620" height="64" rx="12" fill="#f9fbfd" stroke="#b9c7d6" stroke-width="2"/>
+  <text x="356" y="448" fill="#16202a" font-family="Arial, sans-serif" font-size="28">SRV-1042</text>
+  <rect x="330" y="510" width="360" height="72" rx="16" fill="#eaf7ef" stroke="#8bc49a" stroke-width="2"/>
+  <text x="356" y="555" fill="#1f6b36" font-family="Arial, sans-serif" font-size="30" font-weight="700">Welcome, Alex Carter!</text>
+  <text x="330" y="620" fill="#6b7c8f" font-family="Arial, sans-serif" font-size="20">Preview of the persisted form state validated in the browser.</text>
+</svg>

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -1,13 +1,28 @@
 import { useLocalStorage } from "../hooks/useLocalStorage";
+
 function Form() {
+    const [name, setName] = useLocalStorage("name", "");
+    const [serviceNumber, setServiceNumber] = useLocalStorage("serviceNumber", "");
 
     return (
       <>
         <form style={{ display: "flex", flexDirection: "column" }}>
             <label htmlFor="name">Name:</label>
-            <input type="text" data-testid={"name"} />
+            <input
+              id="name"
+              type="text"
+              data-testid={"name"}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
             <label htmlFor="service">Service Number:</label>
-            <input type="text" data-testid={"service"} />
+            <input
+              id="service"
+              type="text"
+              data-testid={"service"}
+              value={serviceNumber}
+              onChange={(event) => setServiceNumber(event.target.value)}
+            />
 
         </form>
         <h4>{name ? `Welcome, ${name}!` : "Enter your name"}</h4>

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,4 +1,17 @@
 import { useEffect, useState } from "react";
 
 export function useLocalStorage(key, initialValue = null) {
+	// Prefer persisted form data when it exists so refreshes preserve the inputs.
+	const [storedValue, setStoredValue] = useState(() => {
+		const valueFromStorage = localStorage.getItem(key);
+
+		return valueFromStorage ?? initialValue;
+	});
+
+	// Keep localStorage synchronized with the latest state for this field.
+	useEffect(() => {
+		localStorage.setItem(key, storedValue);
+	}, [key, storedValue]);
+
+	return [storedValue, setStoredValue];
 }


### PR DESCRIPTION
## Summary
- add a reusable useLocalStorage custom hook
- persist the name and serviceNumber form fields between refreshes
- update the README with the form storage behavior and preview asset